### PR TITLE
Replace an empty string translation with a space

### DIFF
--- a/app/translations/locale-en.json
+++ b/app/translations/locale-en.json
@@ -218,7 +218,7 @@
     "table": "Table",
     "smoothing": "Smoothing",
     "show_diagram": "Show Trend Diagram",
-    "non_time_before": "",
+    "non_time_before": " ",
     "non_time_after": " of selected material lacks time data.",
     "rel_hits_short": "Rel. hits",
     "abs_hits_short": "Abs. hits",


### PR DESCRIPTION
In the English UI of Korp, if you do a trend diagram and some part of the corpus is missing time data (like with Ylilauta), the UI prints eg. "non_time_before99.81% of selected material lacks time data."

I now manually fixed this with a whitespace instead of an empty string to reflect the contents of this commit, but this is not the only empty string, so possibly others should be changed too.