### PR TITLE
Config: Override backend locations on localhost

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -285,6 +285,12 @@ settings.downloadCgiScript = (kielipankkiBaseAddress
                               + (isProductionServerKielipankki ? "/korp" : "")
                               + "/cgi-bin/korp/korp_download.cgi");
 
+// Override backend locations when running on localhost
+if (window.location.hostname == "localhost") {
+    settings.korpBackendURL = "http://localhost:1236";
+    settings.downloadCgiScript = "http://localhost/cgi-bin/korp-2.8-py3/korp_download.cgi";
+}
+
 // The main Korp, Korp Labs and old Korp URLs for the links in the cog menu
 settings.korpUrl = {
     "main": (isProductionServer ? "/korp/" : "/korp/"),


### PR DESCRIPTION
Override backend locations (`settings.korpBackendURL`, `settings.downloadCgiScript`) to point to localhost locations when the frontend is running on localhost. This makes it possible to use the configuration file without modifications both in production and when testing locally.

A problem with this solution is that the exact localhost backend locations are those used by me (@janiemi): someone else might use different locations. However, I don’t know if someone else currently runs Korp locally, and this was the easiest solution I came up with to make it possible to use the configuration file also locally without modifications.