### PR TITLE
Fixes to KWIC downloading

### DIFF
--- a/app/scripts/settings.js
+++ b/app/scripts/settings.js
@@ -57,4 +57,14 @@ export function setDefaultConfigValues() {
         // languages but use the translation key immediately.
         settings.defaultTranslationLanguages = []
     }
+    if (! settings.downloadSendResultMaxSize) {
+        // The maximum query result size (as JSON characters, not
+        // URL-encoded) to send to the KWIC download script; for
+        // larger results, send only the query parameters for the
+        // download script to re-perform the query. By default, always
+        // do the latter. When sending the query result, an updated
+        // korp_download.cgi is needed to produce the same result as
+        // when sending the query parameters.
+        settings.downloadSendResultMaxSize = 0
+    }
 }

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -810,6 +810,18 @@ util.setDownloadLinks = function (query_url, result_data) {
             corpus_config_info_keys: corpus_config_info_keys.join(","),
             urn_resolver: settings.urnResolver,
         }
+        // If the length of the JSONified query result is at most
+        // settings.downloadSendResultMaxSize characters, also send
+        // the query result to avoid re-performing the query
+        const query_result = JSON.stringify(result_data)
+        if (query_result.length <= settings.downloadSendResultMaxSize) {
+            // Convert lower-cased corpus ids in KWIC hits back to
+            // uppercase, to get the same result as when not passing
+            // the query result
+            download_params.query_result = query_result.replaceAll(
+                /("corpus":")(.*?)"/g,
+                (_, p1, p2) => `${p1}${p2.toUpperCase()}"`)
+        }
         if ("downloadFormatParams" in settings) {
             if ("*" in settings.downloadFormatParams) {
                 $.extend(download_params, settings.downloadFormatParams["*"])


### PR DESCRIPTION
Fixes and changes to KWIC downloading:

1. Pass to `korp_download.cgi` the configurations of only those corpora from which hits are included in the result. Previously, the configurations of all corpora between the first and last corpus with hits in the result were passed, even if the result had no hits from some of those corpora.
2. Omit `logicalCorpus` and attribute information from the corpus configurations passed to the download script, as it does not currently use them.
3. If the query result is smaller than a configurable threshold, send it to the KWIC download script instead of only the query parameters, so that the query need not be re-performed. `settings.downloadSendResultMaxSize` determines the maximum size of a query result to be sent (as the number of characters when encoded as JSON, not URL-encoded). This requires the changes to the download script in CSCfi/Kielipankki-korp-ansible#94 to produce the same result as before. If `settings.downloadSendResultMaxSize` is not set, it defaults to `0` to retain the previous behaviour of never sending the query result.

Changes 1 and 2 significantly reduce the size of the request (POST data) passed to `korp_download.cgi`. Change 3 often makes KWIC downloading faster and sometimes is even required to make it succeed by avoiding a server-side timeout, although it increases the size of the request.

In addition, loops in the affected code have been modernized to use `for`...`of`.