### PR TITLE
Configure fixes to KWIC downloading

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -271,6 +271,10 @@ settings.downloadFormatParamsPhysical = {
     },
 };
 
+// The maximum query result size (as JSON characters, not URL-encoded)
+// to send to the KWIC download script; for larger results, send the
+// query parameters for the download script to re-perform the query.
+settings.downloadSendResultMaxSize = 1000000;
 
 // Korp backend URL
 // Currently we, use the backend on the same site as the frontend


### PR DESCRIPTION
Set `settings.downloadSendResultMaxSize` to 1,000,000, to send query results whose JSON representation contains at most one million characters to the KWIC download, instead of making the download script re-perform the query.

This depends on CSCfi/Kielipankki-korp-ansible#94 and #29.