### PR TITLE
KP-11570 Gate private-corpora modes behind login; fix logged-out flow

### DIFF
--- a/app/scripts/auth/fed_auth.ts
+++ b/app/scripts/auth/fed_auth.ts
@@ -152,7 +152,9 @@ const authModule: AuthModule = {
     getCredentials: () => state?.credentials || [],
     getProtectedCorpora: () => state?.protectedCorpora || [],
     getUsername: () => state!.username,
-    isLoggedIn: () => !!state,
+    // `state` is populated even on a 401 (it carries the protected-corpora list),
+    // so an actual login is signalled by the presence of a JWT.
+    isLoggedIn: () => !!state?.jwt,
 }
 
 export default authModule

--- a/app/scripts/data_init.ts
+++ b/app/scripts/data_init.ts
@@ -10,6 +10,7 @@ import { Labeled, LocLangMap, LocMap } from "@/i18n/types"
 import { Attribute, Config, Corpus, CorpusParallel, CustomAttribute } from "@/settings/config.types"
 import { ConfigTransformed, CorpusTransformed } from "@/settings/config-transformed.types"
 import { korpRequest } from "@/backend/common"
+import { auth } from "@/auth/auth"
 import { getLocData } from "@/i18n/loc-data"
 import moment from "moment"
 import { getAllCorporaInFolders } from "./corpora/corpus-chooser"
@@ -141,8 +142,17 @@ export async function fetchInitialData(authDef: Promise<boolean>) {
     // Start fetching translation strings.
     getLocData()
 
-    if (settings.config_dependent_on_authentication) {
+    if (settings.config_dependent_on_authentication || settings.require_login) {
         await authDef
+    }
+
+    // Modes with private corpora (e.g. Mink) are for logged-in users only and must
+    // not expose anything — not even corpus names — to anonymous users. Redirect to
+    // login before the config (and thus the corpus names) is ever fetched.
+    if (settings.require_login && !auth.isLoggedIn()) {
+        auth.login()
+        // Hang until the login redirect navigates away, so private data is never loaded or rendered.
+        await new Promise<never>(() => {})
     }
 
     setDefaultConfigValues()

--- a/app/scripts/settings/app-settings.types.ts
+++ b/app/scripts/settings/app-settings.types.ts
@@ -14,6 +14,13 @@ export type AppSettings = {
     backendURLMaxLength: number
     common_struct_types?: Record<string, Attribute>
     config_dependent_on_authentication?: boolean
+    /**
+     * Redirect anonymous users to the login service before any config or corpora are
+     * loaded. Use for modes whose corpora are private (e.g. Mink), so that corpus
+     * names are never exposed to users who are not logged in. Default off: other
+     * modes still show non-protected corpora, and protected ones (locked), to anyone.
+     */
+    require_login?: boolean
     get_corpus_ids?: () => Promise<string[]>
     corpus_info_link?: {
         url_template: string


### PR DESCRIPTION
This is to fix issues in mink-mode, where the flow for people whose JWT has expired wasn't very nice, and names of Mink corpora could potentially shown to them (or to non-logged in people who just go to Mink mode).

- fed_auth `isLoggedIn()` was truthy for a logged-out user because `state` is populated even on a 401 (it carries the protected-corpora list). Key it off the JWT instead. A logged-out user selecting a protected corpus now takes the login-redirect flow rather than the "access denied" screen.

- Add a `require_login` mode setting (default off). For modes whose corpora are private (Mink), an anonymous user is redirected to login in fetchInitialData *before* getConfig() runs, so corpus names are never fetched or rendered. Other modes are unchanged: they still show non-protected corpora, and protected ones (locked), to anyone.

require_login must be set in the mode's korp_config to take effect.