### PR TITLE
KP-11570 Remove dead protected-corpora auth plumbing

### DIFF
--- a/app/scripts/auth/auth.types.ts
+++ b/app/scripts/auth/auth.types.ts
@@ -18,8 +18,6 @@ export type AuthModule = {
     hasCredential: (corpusId: string) => boolean
     /** Get corpus ids the user has access to */
     getCredentials: () => string[]
-    /** Get list of protected corpus ids (uppercase) from backend */
-    getProtectedCorpora: () => string[]
     getUsername: () => string
     isLoggedIn: () => boolean
 }

--- a/app/scripts/auth/basic_auth.ts
+++ b/app/scripts/auth/basic_auth.ts
@@ -37,7 +37,6 @@ const authModule: AuthModule = {
     getAuthorizationHeader: (): Record<string, string> => (creds ? { Authorization: `Basic ${creds.auth}` } : {}),
     hasCredential: (corpusId) => creds?.credentials?.includes(corpusId.toUpperCase()) || false,
     getCredentials: () => creds?.credentials || [],
-    getProtectedCorpora: () => [], // basic_auth doesn't use backend's protected list
     getUsername: () => creds!.name,
     isLoggedIn: () => !!creds,
 }

--- a/app/scripts/auth/fed_auth.ts
+++ b/app/scripts/auth/fed_auth.ts
@@ -17,7 +17,6 @@ type State = {
     credentials: string[]
     jwt: string
     username: string
-    protectedCorpora: string[]
 }
 
 type JwtPayload = {
@@ -38,11 +37,6 @@ const options = settings.auth_module.options as Options
 
 const authModule: AuthModule = {
     init: async () => {
-        // Fetch protected corpora list (needed even for non-logged-in users to show lock icons)
-        const infoResponse = await fetch(`${settings.korp_backend_url}/info`)
-        const info = await infoResponse.json()
-        const protectedCorpora: string[] = info.protected_corpora || []
-
         const response = await fetch(options.jwt_url, {
             headers: { accept: "text/plain" },
             credentials: "include",
@@ -54,10 +48,14 @@ const authModule: AuthModule = {
             } else {
                 console.warn(`An error has occured: ${response.status}`)
             }
-            // Store protected corpora list even for non-logged-in users
-            state = { jwt: "", username: "", credentials: [], protectedCorpora }
+            state = undefined
             return false
         }
+
+        // Fetch the list of protected corpora, used below to determine which of them the user can access.
+        const infoResponse = await fetch(`${settings.korp_backend_url}/info`, { cache: "no-store" })
+        const info = await infoResponse.json()
+        const protectedCorpora: string[] = info.protected_corpora || []
 
         const jwt = await response.text()
 
@@ -83,47 +81,29 @@ const authModule: AuthModule = {
         // Build credentials based on license requirements
         const credentials: string[] = []
 
-        console.log("[AUTH DEBUG] protectedCorpora:", protectedCorpora)
-        console.log("[AUTH DEBUG] corpusLicenses:", corpusLicenses)
-
         for (const corpusId of protectedCorpora) {
             const corpusUpper = corpusId.toUpperCase()
             const license = corpusLicenses[corpusUpper] || ""
 
             let hasAccess = false
-            let branch: string
-            let permissionLevel = 0
-
             if (license) {
                 // If corpus has a License field, check if user has that class
-                branch = "license"
                 hasAccess = userClasses.includes(license)
             } else {
                 // No License field: RES or mink corpus - requires explicit grant in scope.corpora
                 // Case-insensitive lookup: corpusId is UPPERCASE, normalize scope keys to match
-                branch = "scope.corpora"
-                permissionLevel = Object.entries(scope.corpora || {}).find(
+                const permissionLevel = Object.entries(scope.corpora || {}).find(
                     ([key, _]) => key.toUpperCase() === corpusId
                 )?.[1] || 0
                 hasAccess = permissionLevel >= levels["READ"]
             }
-
-            console.log("[AUTH DEBUG] corpus check:", {
-                corpusId,
-                corpusUpper,
-                license,
-                branch,
-                userClasses,
-                permissionLevel,
-                hasAccess,
-            })
 
             if (hasAccess) {
                 credentials.push(corpusUpper)
             }
         }
 
-        state = { jwt, username, credentials, protectedCorpora }
+        state = { jwt, username, credentials }
 
         return true
     },
@@ -139,18 +119,8 @@ const authModule: AuthModule = {
     },
     logout: () => (window.location.href = options.logout_service),
     getAuthorizationHeader: (): Record<string, string> => (state ? { Authorization: `Bearer ${state.jwt}` } : {}),
-    hasCredential: (corpusId) => {
-        const result = (state?.credentials || []).includes(corpusId)
-        console.log("[AUTH DEBUG] hasCredential", {
-            corpusId,
-            result,
-            credentials: state?.credentials,
-            stateDefined: !!state,
-        })
-        return result
-    },
+    hasCredential: (corpusId) => (state?.credentials || []).includes(corpusId),
     getCredentials: () => state?.credentials || [],
-    getProtectedCorpora: () => state?.protectedCorpora || [],
     getUsername: () => state!.username,
     isLoggedIn: () => !!state,
 }

--- a/app/scripts/auth/init.ts
+++ b/app/scripts/auth/init.ts
@@ -28,7 +28,6 @@ const dummyAuth: AuthModule = {
     getAuthorizationHeader: () => ({}),
     hasCredential: () => false,
     getCredentials: () => [],
-    getProtectedCorpora: () => [],
     getUsername: () => "",
     isLoggedIn: () => false,
 }


### PR DESCRIPTION
There's some now dead code (since a previous PR already) that could be cleaned up.

getProtectedCorpora() lost its only caller in 9d63c307, when updateLimitedAccess() stopped taking the backend protected list (the config / .info sources already cover lock display). Remove the now-unused getter and the state.protectedCorpora field from all auth modules.

The sole purpose of populating `state` on a 401 was to stash that list, so fed_auth now leaves `state` undefined when not logged in (and skips the /info fetch entirely for logged-out users). This also corrects isLoggedIn(), which was truthy for an expired/missing session because `state` was a populated-but-empty object: a logged-out user now takes the login-redirect flow instead of the red "access denied" screen, and no empty "Bearer " header is sent.

Also drop the verbose [AUTH DEBUG] logging.